### PR TITLE
changed: removed ' in path for working on Windows system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 web8p is a command line tool to convert images to webp format
 
+# webp8 on Windows
+
+    # preparing:
+    # install PHP, Composter and cwebp
+    # add pathes for Composter, PHP and cwebp in Environment Variables (sysdm.cpl -> Advanced -> E.V.)
+    # restart system
+    composter install
+
+    # run:
+    php src\webp8.php
+
 # how to install
 
     curl -L -o webp8.phar https://github.com/8ctopus/webp8/releases/download/v0.1.5/webp8.phar
@@ -15,7 +26,7 @@ web8p is a command line tool to convert images to webp format
 
     # move phar to /usr/local/bin/ (optional)
     mv webp8 /usr/local/bin/
-    
+
 ## convert images to webp
 
     ./webp8 convert [--multithreading] [-v] directory

--- a/src/CommandConvert.php
+++ b/src/CommandConvert.php
@@ -189,7 +189,7 @@ class CommandConvert extends Command
         if ($multithreading)
             $options .= ' -mt';
 
-        if (strtoupper(substr(php_uname(), 0, 3)) === 'WIN')
+        if (strtoupper(substr(php_uname('s'), 0, 3)) === 'WIN')
             $command = "cwebp {$options} {$src} -o {$dest}";
         else
             $command = "cwebp {$options} '{$src}' -o '{$dest}'";

--- a/src/CommandConvert.php
+++ b/src/CommandConvert.php
@@ -189,7 +189,7 @@ class CommandConvert extends Command
         if ($multithreading)
             $options .= ' -mt';
 
-        $command = "cwebp {$options} '{$src}' -o '{$dest}'";
+        $command = "cwebp {$options} {$src} -o {$dest}";
 
         $this->io->writeln(PHP_EOL . $command, OutputInterface::VERBOSITY_VERBOSE);
 

--- a/src/CommandConvert.php
+++ b/src/CommandConvert.php
@@ -189,7 +189,7 @@ class CommandConvert extends Command
         if ($multithreading)
             $options .= ' -mt';
 
-        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+        if (strtoupper(substr(php_uname(), 0, 3)) === 'WIN')
             $command = "cwebp {$options} {$src} -o {$dest}";
         else
             $command = "cwebp {$options} '{$src}' -o '{$dest}'";

--- a/src/CommandConvert.php
+++ b/src/CommandConvert.php
@@ -189,7 +189,10 @@ class CommandConvert extends Command
         if ($multithreading)
             $options .= ' -mt';
 
-        $command = "cwebp {$options} {$src} -o {$dest}";
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN')
+            $command = "cwebp {$options} {$src} -o {$dest}";
+        else
+            $command = "cwebp {$options} '{$src}' -o '{$dest}'";
 
         $this->io->writeln(PHP_EOL . $command, OutputInterface::VERBOSITY_VERBOSE);
 


### PR DESCRIPTION
webp8 on Windows

preparing:

- install PHP, [Composter](https://getcomposer.org/Composer-Setup.exe) and [cwebp](https://storage.googleapis.com/downloads.webmproject.org/releases/webp/libwebp-1.2.0-windows-x64.zip)
- add pathes for Composter, PHP and cwebp in Environment Variables (sysdm.cpl -> Advanced -> E.V.)
- restart system
- composter install

run:

php src/webp8.php convert [Directory]